### PR TITLE
Add version_name for Linux distros

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [kpcyrd]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,49 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Run example
+      run: cargo run --example get
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: clippy
+    - uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --workspace --all-targets -- --deny warnings
+
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run cargo fmt
+      run: cargo fmt -- --check

--- a/src/android.rs
+++ b/src/android.rs
@@ -1,17 +1,15 @@
 use anyhow::Result;
 
 #[derive(Debug, PartialEq)]
-pub struct Android {
-}
+pub struct Android {}
 
 impl Android {
-    #[cfg(target_os="android")]
+    #[cfg(target_os = "android")]
     pub fn detect() -> Result<Android> {
-        Ok(Android {
-        })
+        Ok(Android {})
     }
 
-    #[cfg(not(target_os="android"))]
+    #[cfg(not(target_os = "android"))]
     pub fn detect() -> Result<Android> {
         unreachable!()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub use crate::android::Android;
 mod openbsd;
 pub use crate::openbsd::OpenBSD;
 
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 mod winapi;
 
 pub fn detect() -> Result<OsVersion> {

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -8,13 +8,13 @@ pub struct Linux {
 }
 
 impl Linux {
-    #[cfg(target_os="linux")]
+    #[cfg(target_os = "linux")]
     pub fn detect() -> Result<Linux> {
         let file = std::fs::read_to_string("/etc/os-release")?;
         parse(&file)
     }
 
-    #[cfg(not(target_os="linux"))]
+    #[cfg(not(target_os = "linux"))]
     pub fn detect() -> Result<Linux> {
         unreachable!()
     }
@@ -30,7 +30,7 @@ impl ToString for Linux {
     }
 }
 
-#[cfg(target_os="linux")]
+#[cfg(target_os = "linux")]
 fn parse(file: &str) -> Result<Linux> {
     use anyhow::Error;
 
@@ -50,8 +50,7 @@ fn parse(file: &str) -> Result<Linux> {
         }
     }
 
-    let distro = distro
-        .ok_or_else(|| Error::msg("Mandatory ID= field is missing"))?;
+    let distro = distro.ok_or_else(|| Error::msg("Mandatory ID= field is missing"))?;
 
     Ok(Linux {
         distro,
@@ -60,10 +59,10 @@ fn parse(file: &str) -> Result<Linux> {
     })
 }
 
-#[cfg(target_os="linux")]
+#[cfg(target_os = "linux")]
 fn parse_value(mut value: &str) -> Result<String> {
     if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
-        value = &value[1..value.len()-1];
+        value = &value[1..value.len() - 1];
     }
 
     Ok(value.to_string())
@@ -71,13 +70,14 @@ fn parse_value(mut value: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_os="linux")]
+    #[cfg(target_os = "linux")]
     use super::*;
 
     #[test]
-    #[cfg(target_os="linux")]
+    #[cfg(target_os = "linux")]
     fn detect_debian() {
-        let os_release = parse(r#"
+        let os_release = parse(
+            r#"
 NAME="Debian GNU/Linux"
 VERSION_ID="10"
 VERSION="10 (buster)"
@@ -86,18 +86,24 @@ ID=debian
 HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"
 BUG_REPORT_URL="https://bugs.debian.org/"
-"#).unwrap();
-        assert_eq!(Linux {
-            distro: "debian".to_string(),
-            version: Some("10".to_string()),
-            version_name: Some("buster".to_string()),
-        }, os_release);
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            Linux {
+                distro: "debian".to_string(),
+                version: Some("10".to_string()),
+                version_name: Some("buster".to_string()),
+            },
+            os_release
+        );
     }
 
     #[test]
-    #[cfg(target_os="linux")]
+    #[cfg(target_os = "linux")]
     fn detect_archlinux() {
-        let os_release = parse(r#"
+        let os_release = parse(
+            r#"
 NAME="Arch Linux"
 PRETTY_NAME="Arch Linux"
 ID=arch
@@ -108,36 +114,48 @@ DOCUMENTATION_URL="https://wiki.archlinux.org/"
 SUPPORT_URL="https://bbs.archlinux.org/"
 BUG_REPORT_URL="https://bugs.archlinux.org/"
 LOGO=archlinux
-"#).unwrap();
-        assert_eq!(Linux {
-            distro: "arch".to_string(),
-            version: None,
-            version_name: None,
-        }, os_release);
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            Linux {
+                distro: "arch".to_string(),
+                version: None,
+                version_name: None,
+            },
+            os_release
+        );
     }
 
     #[test]
-    #[cfg(target_os="linux")]
+    #[cfg(target_os = "linux")]
     fn detect_alpine() {
-        let os_release = parse(r#"
+        let os_release = parse(
+            r#"
 NAME="Alpine Linux"
 ID=alpine
 VERSION_ID=3.11.5
 PRETTY_NAME="Alpine Linux v3.11"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"
-"#).unwrap();
-        assert_eq!(Linux {
-            distro: "alpine".to_string(),
-            version: Some("3.11.5".to_string()),
-            version_name: None,
-        }, os_release);
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            Linux {
+                distro: "alpine".to_string(),
+                version: Some("3.11.5".to_string()),
+                version_name: None,
+            },
+            os_release
+        );
     }
 
     #[test]
-    #[cfg(target_os="linux")]
+    #[cfg(target_os = "linux")]
     fn detect_ubuntu() {
-        let os_release = parse(r#"
+        let os_release = parse(
+            r#"
 NAME="Ubuntu"
 VERSION="18.04.4 LTS (Bionic Beaver)"
 ID=ubuntu
@@ -150,18 +168,24 @@ BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
 PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
 VERSION_CODENAME=bionic
 UBUNTU_CODENAME=bionic
-"#).unwrap();
-        assert_eq!(Linux {
-            distro: "ubuntu".to_string(),
-            version: Some("18.04".to_string()),
-            version_name: Some("bionic".to_string()),
-        }, os_release);
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            Linux {
+                distro: "ubuntu".to_string(),
+                version: Some("18.04".to_string()),
+                version_name: Some("bionic".to_string()),
+            },
+            os_release
+        );
     }
 
     #[test]
-    #[cfg(target_os="linux")]
+    #[cfg(target_os = "linux")]
     fn detect_centos() {
-        let os_release = parse(r#"
+        let os_release = parse(
+            r#"
 NAME="CentOS Linux"
 VERSION="8 (Core)"
 ID="centos"
@@ -179,11 +203,16 @@ CENTOS_MANTISBT_PROJECT_VERSION="8"
 REDHAT_SUPPORT_PRODUCT="centos"
 REDHAT_SUPPORT_PRODUCT_VERSION="8"
 
-"#).unwrap();
-        assert_eq!(Linux {
-            distro: "centos".to_string(),
-            version: Some("8".to_string()),
-            version_name: None,
-        }, os_release);
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            Linux {
+                distro: "centos".to_string(),
+                version: Some("8".to_string()),
+                version_name: None,
+            },
+            os_release
+        );
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -71,6 +71,7 @@ fn parse_value(mut value: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os="linux")]
     use super::*;
 
     #[test]

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -6,7 +6,7 @@ pub struct OpenBSD {
 }
 
 impl OpenBSD {
-    #[cfg(target_os="openbsd")]
+    #[cfg(target_os = "openbsd")]
     pub fn detect() -> Result<OpenBSD> {
         let uname = uname::Info::new()?;
         Ok(OpenBSD {
@@ -14,7 +14,7 @@ impl OpenBSD {
         })
     }
 
-    #[cfg(not(target_os="openbsd"))]
+    #[cfg(not(target_os = "openbsd"))]
     pub fn detect() -> Result<OpenBSD> {
         unreachable!()
     }

--- a/src/osx.rs
+++ b/src/osx.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct OSX {
     pub version: String,
 }
@@ -47,6 +47,9 @@ fn parse(file: &str) -> Result<OSX> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os="macos")]
+    use super::*;
+
     #[test]
     #[cfg(target_os="macos")]
     fn detect_osx() {
@@ -66,7 +69,7 @@ mod tests {
     <string>10.13.6</string>
 </dict>
 </plist>
-"#);
+"#).unwrap();
         assert_eq!(OSX {
             version: "10.13.6".to_string(),
         }, version);

--- a/src/osx.rs
+++ b/src/osx.rs
@@ -6,13 +6,13 @@ pub struct OSX {
 }
 
 impl OSX {
-    #[cfg(target_os="macos")]
+    #[cfg(target_os = "macos")]
     pub fn detect() -> Result<OSX> {
         let file = std::fs::read_to_string("/System/Library/CoreServices/SystemVersion.plist")?;
         parse(&file)
     }
 
-    #[cfg(not(target_os="macos"))]
+    #[cfg(not(target_os = "macos"))]
     pub fn detect() -> Result<OSX> {
         unreachable!()
     }
@@ -24,34 +24,34 @@ impl ToString for OSX {
     }
 }
 
-#[cfg(target_os="macos")]
+#[cfg(target_os = "macos")]
 fn parse(file: &str) -> Result<OSX> {
     use anyhow::Error;
 
     let cur = std::io::Cursor::new(file.as_bytes());
     let v = plist::Value::from_reader(cur)?;
 
-    let version = v.as_dictionary()
+    let version = v
+        .as_dictionary()
         .ok_or_else(|| Error::msg("SystemVersion.plist is not a dictionary"))?
         .get("ProductVersion")
         .ok_or_else(|| Error::msg("ProductVersion is missing"))?;
 
-    let version = version.as_string()
+    let version = version
+        .as_string()
         .ok_or_else(|| Error::msg("Version is not a string"))?
         .to_string();
 
-    Ok(OSX {
-        version,
-    })
+    Ok(OSX { version })
 }
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_os="macos")]
+    #[cfg(target_os = "macos")]
     use super::*;
 
     #[test]
-    #[cfg(target_os="macos")]
+    #[cfg(target_os = "macos")]
     fn detect_osx() {
         let version = parse(r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -70,8 +70,11 @@ mod tests {
 </dict>
 </plist>
 "#).unwrap();
-        assert_eq!(OSX {
-            version: "10.13.6".to_string(),
-        }, version);
+        assert_eq!(
+            OSX {
+                version: "10.13.6".to_string(),
+            },
+            version
+        );
     }
 }

--- a/src/winapi.rs
+++ b/src/winapi.rs
@@ -1,6 +1,6 @@
 // borrowed from https://github.com/DarkEld3r/os_info/blob/master/src/windows/winapi.rs
 
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use std::mem;
 use winapi::{
     shared::{
@@ -52,7 +52,10 @@ fn get_proc_address(module: &[u8], proc: &[u8]) -> Result<FARPROC> {
 
     let handle = unsafe { GetModuleHandleA(module.as_ptr() as LPCSTR) };
     if handle.is_null() {
-        bail!("GetModuleHandleA({}) failed", String::from_utf8_lossy(module));
+        bail!(
+            "GetModuleHandleA({}) failed",
+            String::from_utf8_lossy(module)
+        );
     }
 
     unsafe { Ok(GetProcAddress(handle, proc.as_ptr() as LPCSTR)) }
@@ -96,7 +99,7 @@ pub fn edition(version_info: &OSVERSIONINFOEX) -> String {
             } else {
                 "server 2003".to_string()
             }
-        },
+        }
         (major, minor, _) => format!("{}.{}", major, minor),
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -6,19 +6,17 @@ pub struct Windows {
 }
 
 impl Windows {
-    #[cfg(target_os="windows")]
+    #[cfg(target_os = "windows")]
     pub fn detect() -> Result<Windows> {
         use crate::winapi;
 
         let version = winapi::version_info()?;
         let version = winapi::edition(&version);
 
-        Ok(Windows {
-            version,
-        })
+        Ok(Windows { version })
     }
 
-    #[cfg(not(target_os="windows"))]
+    #[cfg(not(target_os = "windows"))]
     pub fn detect() -> Result<Windows> {
         unreachable!()
     }


### PR DESCRIPTION
It seems this field is currently only really used by Debian/Ubuntu.